### PR TITLE
build: compile with jdk17 and stop compiling with jdk8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                 axes {
                     axis {
                         name "JDKVERSION"
-                        values "jdk8", "jdk11"
+                        values "jdk11", "jdk17"
                     }
                 }
                 environment {


### PR DESCRIPTION
This pull request updates the `Jenkinsfile` to produce a JDK 17 builder image. It also removes the JDK 8 image, since JDK 8 has not been in use for a while.